### PR TITLE
:sparkles: Accept both String and ICU4X::Locale in available_locales

### DIFF
--- a/lib/rack/icu4x/negotiator.rb
+++ b/lib/rack/icu4x/negotiator.rb
@@ -54,11 +54,11 @@ module Rack
       end
 
       private def build_available_index(locales)
-        locales.map do |locale_str|
-          locale = ::ICU4X::Locale.parse(locale_str)
+        locales.map do |locale_or_str|
+          locale = locale_or_str.is_a?(::ICU4X::Locale) ? locale_or_str : ::ICU4X::Locale.parse(locale_or_str)
           maximized = locale.maximize
           {
-            original: locale_str,
+            original: locale.to_s,
             locale:,
             maximized:,
             language: maximized.language,

--- a/sig/rack/icu4x/locale.rbs
+++ b/sig/rack/icu4x/locale.rbs
@@ -7,15 +7,17 @@ module Rack
       class Error < StandardError
       end
 
+      type locale_input = String | ICU4X::Locale
+
       @app: _RackApp
-      @available_locales: Array[String]
+      @available_locales: Array[locale_input]
       @cookie_name: String?
       @default_locale: String?
       @negotiator: Negotiator
 
       def initialize: (
         _RackApp app,
-        available_locales: Array[String],
+        available_locales: Array[locale_input],
         ?cookie: String?,
         ?strategy: Symbol,
         ?default_locale: String?

--- a/sig/rack/icu4x/negotiator.rbs
+++ b/sig/rack/icu4x/negotiator.rbs
@@ -3,6 +3,8 @@ module Rack
     class Negotiator
       STRATEGIES: Array[Symbol]
 
+      type locale_input = String | ICU4X::Locale
+
       type available_entry = {
         original: String,
         locale: ICU4X::Locale,
@@ -17,7 +19,7 @@ module Rack
       @available: Array[available_entry]
 
       def initialize: (
-        Array[String] available_locales,
+        Array[locale_input] available_locales,
         ?strategy: Symbol,
         ?default_locale: String?
       ) -> void
@@ -28,7 +30,7 @@ module Rack
 
       def validate_strategy!: (Symbol strategy) -> void
       def validate_default_locale!: (Symbol strategy, String? default_locale) -> void
-      def build_available_index: (Array[String] locales) -> Array[available_entry]
+      def build_available_index: (Array[locale_input] locales) -> Array[available_entry]
       def filter_matches: (Array[String] requested_locales) -> Array[String]
       def match_best: (Array[String] requested_locales) -> Array[String]
       def lookup_single: (Array[String] requested_locales) -> Array[String]

--- a/spec/rack/icu4x/negotiator_spec.rb
+++ b/spec/rack/icu4x/negotiator_spec.rb
@@ -156,6 +156,30 @@ RSpec.describe Rack::ICU4X::Negotiator do
     end
   end
 
+  describe "available_locales with ICU4X::Locale instances" do
+    context "with Locale instances only" do
+      let(:locales) { [ICU4X::Locale.parse("en"), ICU4X::Locale.parse("ja")] }
+      let(:negotiator) { Rack::ICU4X::Negotiator.new(locales, strategy: :filtering) }
+
+      it "accepts ICU4X::Locale instances" do
+        expect(negotiator.negotiate(%w[ja])).to eq(%w[ja])
+      end
+
+      it "matches region variant to base language" do
+        expect(negotiator.negotiate(%w[en-US])).to eq(%w[en])
+      end
+    end
+
+    context "with mixed String and Locale instances" do
+      let(:locales) { ["en", ICU4X::Locale.parse("ja")] }
+      let(:negotiator) { Rack::ICU4X::Negotiator.new(locales, strategy: :filtering) }
+
+      it "accepts mixed array" do
+        expect(negotiator.negotiate(%w[ja en])).to eq(%w[ja en])
+      end
+    end
+  end
+
   describe "invalid strategy" do
     it "raises ArgumentError for unknown strategy" do
       expect { Rack::ICU4X::Negotiator.new(%w[en], strategy: :unknown) }


### PR DESCRIPTION
## Summary

Allow `available_locales` to accept both `String` and `ICU4X::Locale` instances for more flexibility.

## Changes

- Update `Negotiator#build_available_index` to handle both types
- Add tests for Locale instances and mixed arrays
- Update RBS type definitions with `locale_input` type alias

Closes #2
