### PR TITLE
:recycle: Rename available_locales option to from

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ gem 'rack-icu4x-locale'
 
 ```ruby
 use Rack::ICU4X::Locale,
-  available_locales: %w[en ja de fr],
+  from: %w[en ja de fr],
   cookie: "locale",           # optional: cookie name for locale override
   default: "en"               # optional: fallback locale when no match
 

--- a/doc/specification.md
+++ b/doc/specification.md
@@ -16,16 +16,16 @@ Rack middleware that generates an array of ICU4X::Locale instances (in preferenc
 
 ```ruby
 use Rack::ICU4X::Locale,
-  available_locales: %w[en-US en-GB ja],  # Required: available locales
-  cookie: "locale",                        # Optional: cookie name
-  default: "en"                            # Optional: fallback locale
+  from: %w[en-US en-GB ja],  # Required: available locales
+  cookie: "locale",          # Optional: cookie name
+  default: "en"              # Optional: fallback locale
 ```
 
 ### Options
 
 | Option | Required | Default | Description |
 |--------|----------|---------|-------------|
-| `available_locales` | Yes | - | Array of available locale identifiers (String or ICU4X::Locale) |
+| `from` | Yes | - | Array of available locale identifiers (String or ICU4X::Locale) |
 | `cookie` | No | nil | Cookie name for locale override |
 | `default` | No | nil | Fallback locale when no match is found (String or ICU4X::Locale) |
 

--- a/lib/rack/icu4x/locale.rb
+++ b/lib/rack/icu4x/locale.rb
@@ -14,10 +14,10 @@ module Rack
     # script boundaries (e.g., zh-TW/Hant will NOT match zh-CN/Hans).
     #
     # @example Basic usage
-    #   use Rack::ICU4X::Locale, available_locales: %w[en ja]
+    #   use Rack::ICU4X::Locale, from: %w[en ja]
     #
     # @example With cookie support
-    #   use Rack::ICU4X::Locale, available_locales: %w[en ja], cookie: "locale"
+    #   use Rack::ICU4X::Locale, from: %w[en ja], cookie: "locale"
     class Locale
       ENV_KEY = "rack.icu4x.locale"
       public_constant :ENV_KEY
@@ -25,15 +25,15 @@ module Rack
       class Error < StandardError; end
 
       # @param app [#call] The Rack application
-      # @param available_locales [Array<String, ICU4X::Locale>] List of available locales
+      # @param from [Array<String, ICU4X::Locale>] List of available locales
       # @param cookie [String, nil] Cookie name for locale preference (optional)
       # @param default [String, ICU4X::Locale, nil] Default locale when no match is found (optional)
-      def initialize(app, available_locales:, cookie: nil, default: nil)
+      def initialize(app, from:, cookie: nil, default: nil)
         @app = app
-        @available_locales = available_locales
+        @from = from
         @cookie_name = cookie
         @default = default && normalize_locale(default)
-        @negotiator = Negotiator.new(available_locales)
+        @negotiator = Negotiator.new(from)
       end
 
       # @param env [Hash] Rack environment

--- a/sig/rack/icu4x/locale.rbs
+++ b/sig/rack/icu4x/locale.rbs
@@ -10,14 +10,14 @@ module Rack
       type locale_input = String | ICU4X::Locale
 
       @app: _RackApp
-      @available_locales: Array[locale_input]
+      @from: Array[locale_input]
       @cookie_name: String?
       @default: ICU4X::Locale?
       @negotiator: Negotiator
 
       def initialize: (
         _RackApp app,
-        available_locales: Array[locale_input],
+        from: Array[locale_input],
         ?cookie: String?,
         ?default: locale_input?
       ) -> void

--- a/spec/rack/icu4x/locale_spec.rb
+++ b/spec/rack/icu4x/locale_spec.rb
@@ -2,8 +2,8 @@
 
 RSpec.describe Rack::ICU4X::Locale do
   let(:app) { ->(env) { [200, {}, [env[Rack::ICU4X::Locale::ENV_KEY].map(&:to_s).join(",")]] } }
-  let(:available_locales) { %w[en ja de] }
-  let(:middleware) { Rack::ICU4X::Locale.new(app, available_locales:) }
+  let(:from) { %w[en ja de] }
+  let(:middleware) { Rack::ICU4X::Locale.new(app, from:) }
 
   describe "#call" do
     context "with Accept-Language header" do
@@ -66,7 +66,7 @@ RSpec.describe Rack::ICU4X::Locale do
   end
 
   describe "with cookie option" do
-    let(:middleware) { Rack::ICU4X::Locale.new(app, available_locales:, cookie: "locale") }
+    let(:middleware) { Rack::ICU4X::Locale.new(app, from:, cookie: "locale") }
 
     context "when cookie is set with valid locale" do
       it "returns the locale from cookie" do
@@ -125,7 +125,7 @@ RSpec.describe Rack::ICU4X::Locale do
 
   describe "language negotiation" do
     context "with regional variants" do
-      let(:middleware) { Rack::ICU4X::Locale.new(app, available_locales: %w[en-US en-GB ja]) }
+      let(:middleware) { Rack::ICU4X::Locale.new(app, from: %w[en-US en-GB ja]) }
 
       it "matches exact regional variant" do
         env = Rack::MockRequest.env_for("/", "HTTP_ACCEPT_LANGUAGE" => "en-GB")
@@ -147,7 +147,7 @@ RSpec.describe Rack::ICU4X::Locale do
     end
 
     context "with script-sensitive locales (Chinese)" do
-      let(:middleware) { Rack::ICU4X::Locale.new(app, available_locales: %w[zh-CN en]) }
+      let(:middleware) { Rack::ICU4X::Locale.new(app, from: %w[zh-CN en]) }
 
       it "does not match zh-TW to zh-CN (different scripts)" do
         env = Rack::MockRequest.env_for("/", "HTTP_ACCEPT_LANGUAGE" => "zh-TW")
@@ -165,7 +165,7 @@ RSpec.describe Rack::ICU4X::Locale do
 
   describe "with default option" do
     context "when default is a String" do
-      let(:middleware) { Rack::ICU4X::Locale.new(app, available_locales:, default: "en") }
+      let(:middleware) { Rack::ICU4X::Locale.new(app, from:, default: "en") }
 
       it "returns default locale when no match is found" do
         env = Rack::MockRequest.env_for("/", "HTTP_ACCEPT_LANGUAGE" => "fr")
@@ -189,7 +189,7 @@ RSpec.describe Rack::ICU4X::Locale do
     end
 
     context "when default is an ICU4X::Locale" do
-      let(:middleware) { Rack::ICU4X::Locale.new(app, available_locales:, default: ICU4X::Locale.parse("en")) }
+      let(:middleware) { Rack::ICU4X::Locale.new(app, from:, default: ICU4X::Locale.parse("en")) }
 
       it "returns default locale when no match is found" do
         env = Rack::MockRequest.env_for("/")


### PR DESCRIPTION
## Summary
Rename the verbose `available_locales:` option to `from:` for a more concise API.

## Changes
- Rename `available_locales:` parameter to `from:`
- Update RBS type definitions
- Update tests and documentation

## Before
```ruby
use Rack::ICU4X::Locale,
  available_locales: %w[en ja de],
  cookie: "locale",
  default: "en"
```

## After
```ruby
use Rack::ICU4X::Locale,
  from: %w[en ja de],
  cookie: "locale",
  default: "en"
```

Closes #6
