### PR TITLE
:sparkles: Validate default is included in available locales

### DIFF
--- a/lib/rack/icu4x/negotiator.rb
+++ b/lib/rack/icu4x/negotiator.rb
@@ -8,10 +8,11 @@ module Rack
     # to avoid politically sensitive fallbacks (e.g., zh-TW won't match zh-CN).
     #
     # @example
-    #   negotiator = Rack::ICU4X::Negotiator.new(%w[en-US en-GB ja])
+    #   locales = %w[en-US en-GB ja].map { ICU4X::Locale.parse(_1) }
+    #   negotiator = Rack::ICU4X::Negotiator.new(locales)
     #   negotiator.negotiate(%w[en-AU ja-JP])  # => ["en-US", "ja"]
     class Negotiator
-      # @param available_locales [Array<String, ICU4X::Locale>] List of available locales
+      # @param available_locales [Array<ICU4X::Locale>] List of available locales
       def initialize(available_locales)
         @available = build_available_index(available_locales)
       end
@@ -46,8 +47,7 @@ module Rack
       end
 
       private def build_available_index(locales)
-        locales.map do |locale_or_str|
-          locale = locale_or_str.is_a?(::ICU4X::Locale) ? locale_or_str : ::ICU4X::Locale.parse(locale_or_str)
+        locales.map do |locale|
           maximized = locale.maximize
           {
             original: locale.to_s,

--- a/sig/rack/icu4x/locale.rbs
+++ b/sig/rack/icu4x/locale.rbs
@@ -10,7 +10,7 @@ module Rack
       type locale_input = String | ICU4X::Locale
 
       @app: _RackApp
-      @from: Array[locale_input]
+      @from: Array[ICU4X::Locale]
       @cookie_name: String?
       @default: ICU4X::Locale?
       @negotiator: Negotiator
@@ -25,6 +25,7 @@ module Rack
 
       private
 
+      def validate_default_in_from!: () -> void
       def detect_locales: (Hash[String, untyped] env) -> Array[ICU4X::Locale]
       def normalize_locale: (locale_input locale) -> ICU4X::Locale
       def cookie_locale: (Hash[String, untyped] env) -> Array[ICU4X::Locale]?

--- a/sig/rack/icu4x/negotiator.rbs
+++ b/sig/rack/icu4x/negotiator.rbs
@@ -1,8 +1,6 @@
 module Rack
   module ICU4X
     class Negotiator
-      type locale_input = String | ICU4X::Locale
-
       type available_entry = {
         original: String,
         locale: ICU4X::Locale,
@@ -14,13 +12,13 @@ module Rack
 
       @available: Array[available_entry]
 
-      def initialize: (Array[locale_input] available_locales) -> void
+      def initialize: (Array[ICU4X::Locale] available_locales) -> void
 
       def negotiate: (Array[String] requested_locales) -> Array[String]
 
       private
 
-      def build_available_index: (Array[locale_input] locales) -> Array[available_entry]
+      def build_available_index: (Array[ICU4X::Locale] locales) -> Array[available_entry]
       def maximize_locale: (String locale_str) -> ICU4X::Locale
       def find_exact_match: (Array[available_entry] candidates, ICU4X::Locale req_max) -> available_entry?
       def find_lang_script_match: (Array[available_entry] candidates, ICU4X::Locale req_max) -> available_entry?

--- a/spec/rack/icu4x/locale_spec.rb
+++ b/spec/rack/icu4x/locale_spec.rb
@@ -201,6 +201,14 @@ RSpec.describe Rack::ICU4X::Locale do
         expect(locales[0].to_s).to eq("en")
       end
     end
+
+    context "when default is not in from" do
+      it "raises an error" do
+        expect {
+          Rack::ICU4X::Locale.new(app, from:, default: "fr")
+        }.to raise_error(Rack::ICU4X::Locale::Error, /default "fr" is not in available locales/)
+      end
+    end
   end
 
   describe "ENV_KEY" do


### PR DESCRIPTION
## Summary
Validate that `default:` option is included in `from:` locales at initialization time.

## Changes
- Raise `Rack::ICU4X::Locale::Error` if `default` is not in `from`
- Normalize `from` array to `ICU4X::Locale` at initialization
- Negotiator now expects `ICU4X::Locale` array only (internal change)

## Example
```ruby
# Raises error at startup
use Rack::ICU4X::Locale,
  from: %w[en ja],
  default: "fr"  # => Error: default "fr" is not in available locales
```

Closes #7
