### PR TITLE
:arrow_up: Update Ruby versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.2", "3.3", "3.4", "4.0"]
+        ruby: ["3.3", "3.4", "4.0"]
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: "3.2"
+        ruby-version: "3.3"
         bundler-cache: true
 
     - name: Build gem

--- a/.github/workflows/release-validation.yml
+++ b/.github/workflows/release-validation.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: "3.2"
+        ruby-version: "3.3"
         bundler-cache: true
 
     - name: Extract version from branch name

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,7 @@ AllCops:
     - examples/vendor/**/*
   ExtraDetails: true
   NewCops: enable
-  TargetRubyVersion: 3.2
+  TargetRubyVersion: 3.3
   UseCache: true
 
 inherit_mode:

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-ruby = "3.2"
+ruby = "3.3"
 
 [env]
 _.path = ["bin", "exe"]

--- a/rack-icu4x-locale.gemspec
+++ b/rack-icu4x-locale.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description = "rack-icu4x-locale"
   spec.homepage = "https://github.com/sakuro/rack-icu4x-locale"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 3.2"
+  spec.required_ruby_version = ">= 3.3"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "#{spec.homepage}.git"

--- a/spec/rack/icu4x/locale_spec.rb
+++ b/spec/rack/icu4x/locale_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Rack::ICU4X::Locale do
-  let(:app) { ->(env) { [200, {}, [env[Rack::ICU4X::Locale::ENV_KEY].map(&:to_s).join(",")]] } }
+  let(:app) { ->(env) { [200, {}, [env[Rack::ICU4X::Locale::ENV_KEY].join(",")]] } }
   let(:locales) { %w[en ja de] }
   let(:middleware) { Rack::ICU4X::Locale.new(app, locales:) }
 


### PR DESCRIPTION
Automated update of maintained Ruby versions from Ruby's official branches.yml.

This PR updates:
- `.github/workflows/ci.yml` test matrix to include all maintained Ruby versions
- `.github/workflows/release-*.yml` ruby-version to match the minimum Ruby version
- `.rubocop.yml` TargetRubyVersion to match the minimum Ruby version
- `*.gemspec` required_ruby_version to match the minimum Ruby version
- `mise.toml` ruby version to match the minimum Ruby version
