### PR TITLE
:sparkles: Collect matches from all detectors instead of stopping at first match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Changed
+
+- Collect matches from all detectors instead of stopping at first match (#16)
+
 ## [0.6.0] - 2026-05-08
 
 ### Changed

--- a/lib/rack/icu4x/locale.rb
+++ b/lib/rack/icu4x/locale.rb
@@ -77,6 +77,7 @@ module Rack
       end
 
       private def try_detectors(env)
+        result = []
         @detectors.each do |detector|
           raw = detector.call(env)
           next if raw.nil?
@@ -85,9 +86,9 @@ module Rack
           matched = @negotiator.negotiate(requested) {|invalid_locale|
             log_invalid_locale(env, invalid_locale)
           }
-          return matched.map {|locale| ::ICU4X::Locale.parse(locale) } unless matched.empty?
+          result.concat(matched)
         end
-        []
+        result.uniq.map! {|locale| ::ICU4X::Locale.parse(locale) }
       end
 
       private def normalize_locale(locale) = locale.is_a?(::ICU4X::Locale) ? locale : ::ICU4X::Locale.parse(locale)

--- a/spec/rack/icu4x/locale_spec.rb
+++ b/spec/rack/icu4x/locale_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe Rack::ICU4X::Locale do
         expect(locales[0].to_s).to eq("ja")
       end
 
-      it "ignores Accept-Language header when cookie is set" do
+      it "puts cookie locale first, then Accept-Language locales" do
         env = Rack::MockRequest.env_for(
           "/",
           "HTTP_COOKIE" => "locale=de",
@@ -89,8 +89,10 @@ RSpec.describe Rack::ICU4X::Locale do
         middleware.call(env)
 
         locales = env[Rack::ICU4X::Locale::ENV_KEY]
-        expect(locales.size).to eq(1)
+        expect(locales.size).to eq(3)
         expect(locales[0].to_s).to eq("de")
+        expect(locales[1].to_s).to eq("ja")
+        expect(locales[2].to_s).to eq("en")
       end
 
       it "falls back to Accept-Language when cookie has unavailable locale" do
@@ -131,14 +133,15 @@ RSpec.describe Rack::ICU4X::Locale do
         expect(locales[0].to_s).to eq("ja")
       end
 
-      it "prefers query parameter over Accept-Language" do
+      it "puts query locale first, then Accept-Language locales" do
         env = Rack::MockRequest.env_for("/?lang=de", "HTTP_ACCEPT_LANGUAGE" => "ja")
 
         middleware.call(env)
 
         locales = env[Rack::ICU4X::Locale::ENV_KEY]
-        expect(locales.size).to eq(1)
+        expect(locales.size).to eq(2)
         expect(locales[0].to_s).to eq("de")
+        expect(locales[1].to_s).to eq("ja")
       end
     end
 
@@ -184,6 +187,32 @@ RSpec.describe Rack::ICU4X::Locale do
 
         locales = env[Rack::ICU4X::Locale::ENV_KEY]
         expect(locales[0].to_s).to eq("en")
+      end
+
+      it "collects matches from all detectors in priority order" do
+        env = Rack::MockRequest.env_for(
+          "/?lang=de",
+          "HTTP_COOKIE" => "locale=ja",
+          "HTTP_ACCEPT_LANGUAGE" => "en"
+        )
+
+        middleware.call(env)
+
+        locales = env[Rack::ICU4X::Locale::ENV_KEY]
+        expect(locales.map(&:to_s)).to eq(%w[de ja en])
+      end
+
+      it "deduplicates locales across detectors" do
+        env = Rack::MockRequest.env_for(
+          "/?lang=ja",
+          "HTTP_COOKIE" => "locale=ja",
+          "HTTP_ACCEPT_LANGUAGE" => "ja,en;q=0.9"
+        )
+
+        middleware.call(env)
+
+        locales = env[Rack::ICU4X::Locale::ENV_KEY]
+        expect(locales.map(&:to_s)).to eq(%w[ja en])
       end
     end
 


### PR DESCRIPTION
## Summary

Run all detectors and merge their results, so callers can build a complete locale fallback chain from a single `ENV_KEY` lookup.

## Changes

- `try_detectors` now runs every detector instead of returning on the first match
- Results are deduplicated (preserving priority order) before being stored in `ENV_KEY`
- Updated tests to reflect new behavior; added tests for full collection and deduplication

## Before

Session locale `"ja"` + `Accept-Language: ja, en;q=0.9` → `["ja"]`

## After

Session locale `"ja"` + `Accept-Language: ja, en;q=0.9` → `["ja", "en"]`

Closes #16
